### PR TITLE
Use nowitis/tkey-deviceapp-builder image

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+Checks: '-*,bugprone-*,llvm-*'
+CheckOptions:
+    - key: bugprone-argument-comment.StrictMode
+      value: 1
+FormatStyle: 'file'
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/munit"]
+	path = tests/munit
+	url = https://github.com/nemequ/munit.git

--- a/README.md
+++ b/README.md
@@ -6,8 +6,21 @@ Only contains SHA1 & HMAC-SHA1 – for now.
 - SHA1 & HMAC-SHA1: `libsha`.
   - see copyright headers. 
 
-## Licenses and SPDX tags
+## Building
+We advise to build the libraries with our OCI image 
+`ghcr.io/nowitis/tkey-deviceapp-builder`. 
 
+Then:
+```
+make podman
+```
+
+Please see the
+[README on the tkey-libs repo](https://github.com/tillitis/tkey-libs)
+for detailed information on the currently supported build and development
+environment.
+
+## Licenses and SPDX tags
 Unless otherwise noted, the project sources are licensed under the
 terms and conditions of the "GNU General Public License v2.0 only".
 See [LICENSE](LICENSE) for the full GPLv2-only license text.
@@ -25,25 +38,3 @@ The current set of valid, predefined SPDX identifiers can be found on
 the SPDX License List at:
 
 https://spdx.org/licenses/
-
-## Building
-
-To build you need at least `make`, `clang`, `llvm`, and `lld` packages installed. 
-
-Version 15 or later of LLVM/Clang is required for the RV32IC\_Zmmul
-architecture we use. Ubuntu 22.10 (Kinetic) is known to work. Please
-see the
-[README on the tkey-libs repo](https://github.com/tillitis/tkey-libs)
-for detailed information on the currently supported build and development
-environment.
-
-## Building using podman
-
-You can also build the libraries with our OCI image
-`ghcr.io/tillitis/tkey-builder`. 
-
-The easiest way to build this is if you have `make` installed:
-
-```
-make podman
-```


### PR DESCRIPTION
Our image includes `clang-lint` for linting, contrary to the original Tillitis image.